### PR TITLE
Account for overrun up to integer overflow

### DIFF
--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -36,7 +36,15 @@
 #if (CONFIG_KERNEL_STATIC_MAX_BUDGET_US) != 0
 #define MAX_BUDGET_US (CONFIG_KERNEL_STATIC_MAX_BUDGET_US)
 #else
-#define MAX_BUDGET_US getMaxUsToTicks()
+/* The maximum period determines the point at which the scheduling logic
+ * will no longer function correctly (UINT64_MAX - 3 * MAX_PERIOD), so
+ * we keep the maximum period relatively small to ensure that the system
+ * can function for a reasonably long time.
+ *
+ * Anything below getMaxUsToTicks() / 8 would ensure that time up to
+ * 2^63 would still be be valid as 3 * (getMaxUsToTicks()) must be less
+ * than 2^63. */
+#define MAX_BUDGET_US (getMaxUsToTicks() / 8)
 #endif /* CONFIG_KERNEL_STATIC_MAX_BUDGET_US != 0 */
 
 /* Short hand for accessing refill queue items */

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -319,13 +319,6 @@ void refill_budget_check(ticks_t usage)
         refill_head(sc)->rTime -= head.rAmount;
     }
 
-    /* Ensure that the refills are now not disjoint */
-    while (unlikely(refill_head_overlapping(sc))) {
-        refill_t head = refill_pop_head(sc);
-        refill_head(sc)->rAmount += head.rAmount;
-        refill_head(sc)->rTime = head.rTime;
-    }
-
     REFILL_SANITY_END(sc);
 }
 

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -255,20 +255,38 @@ void refill_budget_check(ticks_t usage)
     assert(!isRoundRobin(sc));
     REFILL_SANITY_START(sc);
 
-    /* We assume that the estimates on worst-case kernel overheads are
-     * an upper bound and that overrun cannot occur. */
-#ifdef CONFIG_DEBUG_BUILD
-    if (usage > refill_head(sc)->rAmount) {
-        ticks_t overrun = usage - refill_head(sc)->rAmount;
-        userError(
-            "SC (%p) overran budget by %lluus (%llu ticks)",
-            sc,
-            ticksToUs(overrun),
-            overrun
-        );
+    /*
+     * We charge entire refills in a loop until we end up with a partial
+     * refill or at a point where we can't place refills into the future
+     * without integer overflow.
+     *
+     * Verification actually requires that the current time is at least
+     * 3 * MAX_PERIOD from the INT64_MAX value, so to ease relation to
+     * that assertion we ensure that we never delate a refill past this
+     * point in the future.
+     */
+    while (
+        refill_head(sc)->rAmount <= usage &&
+        INT64_MAX - refill_head(sc)->rTime >= 3 * usToTicks(MAX_BUDGET_US)
+    ) {
+        usage -= refill_head(sc)->rAmount;
+
+        if (refill_single(sc)) {
+            refill_head(sc)->rTime += sc->scPeriod;
+        } else {
+            ticks_t old_head = refill_pop_head(sc);
+            old_head.rTime += sc->scPeriod;
+            schedule_used(sc, old_head);
+        }
     }
-#endif
-    usage = MIN(usage, refill_head(sc)->rAmount);
+
+    /*
+     * If the usage is still greater than the head, we must be at a
+     * point where we cannot charge time to this SC without overflowing
+     */
+    if (refill_head(sc)->rAmount <= usage) {
+        return;
+    }
 
     /* Charge the usage to the head refill */
     if (usage > 0) {


### PR DESCRIPTION
This re-introduces the overrun handling but bounds charging of budget such that we never calculate a refill with a start using an integer overflow.

Based on the suggestion from @lsf37 to ease verification without needing a complex expression for the bound on current time for a valid system.

@michaelmcinerney is hopeful this will work out and will attempt to incorporate this version into the abstract spec and we'll check in next week to see if any adjustments are needed to make it work in the proof.