### PR TITLE
squash! mcs: Alter overflow checking for easy verification

### DIFF
--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -197,13 +197,8 @@ void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, 
         refill_head(sc)->rTime = NODE_STATE_ON_CORE(ksCurTime, sc->scCore);
     }
 
-    if (
-        refill_head(sc)->rAmount >= new_budget ||
-        INT64_MAX - refill_head(sc)->rTime < 4 * usToTicks(MAX_BUDGET_US)
-    ) {
-        /* if the heads budget exceeds the new budget just trim it
-         * and if the refill would end up past the point where we can
-         * correctly schedule it, just schedule it where it is */
+    if (refill_head(sc)->rAmount >= new_budget) {
+        /* if the heads budget exceeds the new budget just trim it */
         refill_head(sc)->rAmount = new_budget;
         maybe_add_empty_tail(sc);
     } else {
@@ -272,7 +267,7 @@ void refill_budget_check(ticks_t usage)
      */
     while (
         refill_head(sc)->rAmount <= usage &&
-        INT64_MAX - refill_head(sc)->rTime >= 4 * usToTicks(MAX_BUDGET_US)
+        INT64_MAX - refill_head(sc)->rTime >= 5 * usToTicks(MAX_BUDGET_US)
     ) {
         usage -= refill_head(sc)->rAmount;
 

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -335,10 +335,9 @@ void refill_unblock_check(sched_context_t *sc)
 
         /* merge available replenishments */
         while (refill_head_overlapping(sc)) {
-            ticks_t amount = refill_head(sc)->rAmount;
-            refill_pop_head(sc);
-            refill_head(sc)->rAmount += amount;
-            refill_head(sc)->rTime = NODE_STATE_ON_CORE(ksCurTime, sc->scCore);
+            refill_t old_head = refill_pop_head(sc);
+            refill_head(sc)->rTime = old_head.rTime;
+            refill_head(sc)->rAmount += old_head.rAmount;
         }
 
         assert(refill_sufficient(sc, 0));


### PR DESCRIPTION
Need to ensure we never produce a refill outside the overflow bound and
want to avoid proving the invariant needed to show that here.

Signed-off-by: Curtis Millar <curtis.millar@data61.csiro.au>