### PR TITLE
gicv3: Split EOI mode

### DIFF
--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -335,17 +335,29 @@ static inline void maskInterrupt(bool_t disable, irq_t irq)
     }
 }
 
-static inline void ackInterrupt(irq_t irq)
+static inline void prioDropInterrupt(irq_t irq)
 {
     word_t hw_irq = IRQT_TO_IRQ(irq);
-    assert(IS_IRQ_VALID(active_irq[CURRENT_CPU_INDEX()]) && (active_irq[CURRENT_CPU_INDEX()] & IRQ_MASK) == hw_irq);
+    /* Perform priority drop for current IRQ */
+    SYSTEM_WRITE_WORD(ICC_EOIR1_EL1, hw_irq);
 
-    if (is_irq_edge_triggered(hw_irq)) {
-        gic_pending_clr(hw_irq);
-    }
+}
+
+static inline void deactivateInterrupt(irq_t irq)
+{
+    word_t hw_irq = IRQT_TO_IRQ(irq);
+    /* Perform deactivation of hw_irq */
+    SYSTEM_WRITE_WORD(ICC_DIR_EL1, hw_irq);
+}
+
+
+static inline void ackInterrupt(irq_t irq)
+{
+    assert(IS_IRQ_VALID(active_irq[CURRENT_CPU_INDEX()]) && (active_irq[CURRENT_CPU_INDEX()] & IRQ_MASK) == IRQT_TO_IRQ(irq));
+
 
     /* Set End of Interrupt for active IRQ: ICC_EOIR1_EL1 */
-    SYSTEM_WRITE_WORD(ICC_EOIR1_EL1, active_irq[CURRENT_CPU_INDEX()]);
+    prioDropInterrupt(irq);
     active_irq[CURRENT_CPU_INDEX()] = IRQ_NONE;
 
 }

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -277,7 +277,7 @@ BOOT_CODE static void cpu_iface_init(void)
 
     /* EOI drops priority and deactivates the interrupt: ICC_CTLR_EL1 */
     SYSTEM_READ_WORD(ICC_CTLR_EL1, icc_ctlr);
-    icc_ctlr &= ~GICC_CTLR_EL1_EOImode_drop;
+    icc_ctlr |= GICC_CTLR_EL1_EOImode_drop;
     SYSTEM_WRITE_WORD(ICC_CTLR_EL1, icc_ctlr);
 
     /* Enable Group1 interrupts: ICC_IGRPEN1_EL1 */


### PR DESCRIPTION
Separate priority drop from deactivation so that when the kernel delegates interrupts to userlevel, they can be left in the active state until user level performs the ack invocation which deactivates them. This is likely more efficient than doing a disable and enable operation for each handled interrupt.