### PR TITLE
arm/gic: disable interrupt before modifying GICD_ICFGRn

### DIFF
--- a/src/arch/arm/machine/gic_v2.c
+++ b/src/arch/arm/machine/gic_v2.c
@@ -152,13 +152,28 @@ void setIRQTrigger(irq_t irq, bool_t trigger)
     /* in the gic_config, there is a 2 bit field for each irq,
      * setting the most significant bit of this field makes the irq edge-triggered,
      * while 0 indicates that it is level-triggered */
-    word_t index = IRQT_TO_IRQ(irq) / 16u;
-    word_t offset = (IRQT_TO_IRQ(irq) % 16u) * 2;
+    word_t hw_irq = IRQT_TO_IRQ(irq);
+    word_t index = hw_irq / 16u;
+    word_t offset = (hw_irq % 16u) * 2;
+
+    /* Per ARM GIC spec, the interrupt must be disabled before changing
+     * its configuration, otherwise GIC behavior is UNPREDICTABLE. */
+    int word = IRQ_REG(hw_irq);
+    int bit = IRQ_BIT(hw_irq);
+    bool_t was_enabled = !!(gic_dist->enable_set[word] & BIT(bit));
+
+    if (was_enabled) {
+        dist_enable_clr(hw_irq);
+    }
+
     if (trigger) {
-        /* set the bit */
         gic_dist->config[index] |= BIT(offset + 1);
     } else {
         gic_dist->config[index] &= ~BIT(offset + 1);
+    }
+
+    if (was_enabled) {
+        dist_enable_set(hw_irq);
     }
 }
 

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -304,7 +304,6 @@ BOOT_CODE static void cpu_iface_init(void)
 
 void setIRQTrigger(irq_t irq, bool_t trigger)
 {
-
     /* GICv3 has read-only GICR_ICFG0 for SGI with
      * default value 0xaaaaaaaa, and read-write GICR_ICFG1
      * for PPI with default 0x00000000.*/
@@ -315,6 +314,23 @@ void setIRQTrigger(irq_t irq, bool_t trigger)
     }
     int word = hw_irq >> 4;
     int bit = ((hw_irq & 0xf) * 2);
+
+    /* Per ARM GIC spec, the interrupt must be disabled before changing
+     * its configuration, otherwise GIC behavior is UNPREDICTABLE. */
+    int en_word = IRQ_REG(hw_irq);
+    int en_bit = IRQ_BIT(hw_irq);
+    bool_t was_enabled;
+
+    if (HW_IRQ_IS_PPI(hw_irq)) {
+        was_enabled = !!(gic_rdist_sgi_ppi_map[core]->isenabler0 & BIT(en_bit));
+    } else {
+        was_enabled = !!(gic_dist->isenablern[en_word] & BIT(en_bit));
+    }
+
+    if (was_enabled) {
+        gic_enable_clr(hw_irq);
+    }
+
     uint32_t icfgr = 0;
     if (HW_IRQ_IS_PPI(hw_irq)) {
         icfgr = gic_rdist_sgi_ppi_map[core]->icfgr1;
@@ -331,13 +347,12 @@ void setIRQTrigger(irq_t irq, bool_t trigger)
     if (HW_IRQ_IS_PPI(hw_irq)) {
         gic_rdist_sgi_ppi_map[core]->icfgr1 = icfgr;
     } else {
-        /* Update GICD_ICFGR<n>. Note that the interrupt should
-         * be disabled before changing the field, and this function
-         * assumes the caller has disabled the interrupt. */
         gic_dist->icfgrn[word] = icfgr;
     }
 
-    return;
+    if (was_enabled) {
+        gic_enable_set(hw_irq);
+    }
 }
 
 BOOT_CODE void initIRQController(void)


### PR DESCRIPTION
Per the ARM GIC specification, modifying a programmable Int_config field while the corresponding interrupt is enabled results in UNPREDICTABLE behavior. setIRQTrigger currently modifies GICD_ICFGRn (GICv2) and GICD_ICFGR/GICR_ICFGR (GICv3) without first disabling the interrupt.

Fix both GICv2 and GICv3 implementations to:
1. Check if the interrupt is currently enabled by reading the GICD_ISENABLER / GICR_ISENABLER register.
2. Disable the interrupt if it was enabled.
3. Modify the configuration register.
4. Re-enable the interrupt if it was previously enabled.

While the current sole call site (Arch_invokeIRQControl) configures interrupts before they are enabled, this fix makes setIRQTrigger safe for any future callers that may reconfigure already-enabled interrupts.

Resolves seL4/seL4#290